### PR TITLE
added fallbacl for placeholder image for undefinded image src

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image ? item.image : '/placeholder.png'}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Added fallback for items in the gallery with no image. Now a placeholder will be shown if no image is given.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (if relevant)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

# How Has This Been Tested?

- Tested items with no image are now indeed presented with the placeholder image
- Tested that items that have an image aren't affected

**If this is a UI change / fix, please also add a screenshot**
![image](https://user-images.githubusercontent.com/2714500/152530901-fbe0c020-974a-4361-b043-ee8bb6620989.png)

# Checklist:

- [ X ] I have performed a self-review of my own code
- [ X ] My changes generate no new warnings
- [ X ] I added the relevant people as reviewers to my PR
